### PR TITLE
add HandlerScanner to allow adding jetty handlers through injection

### DIFF
--- a/gwizard-web/pom.xml
+++ b/gwizard-web/pom.xml
@@ -36,5 +36,11 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-access</artifactId>
+			<version>${logback.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/gwizard-web/src/main/java/org/gwizard/web/HandlerScanner.java
+++ b/gwizard-web/src/main/java/org/gwizard/web/HandlerScanner.java
@@ -1,0 +1,46 @@
+package org.gwizard.web;
+
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import org.eclipse.jetty.server.Handler;
+
+import javax.inject.Inject;
+import java.lang.reflect.Type;
+import java.util.EventListener;
+
+/**
+ * Walks through the guice injector bindings, visiting each one that is a Handler.
+ */
+public class HandlerScanner {
+	public interface Visitor {
+		void visit(Handler handler);
+	}
+
+	private final Injector injector;
+
+	@Inject
+	public HandlerScanner(Injector injector) {
+		this.injector = injector;
+	}
+
+	/** Start the process, visiting each ServletContextListener bound in the injector or any parents */
+	public void accept(Visitor visitor) {
+		accept(injector, visitor);
+	}
+
+	/** Recursive impl that walks up the parent injectors first */
+	private void accept(Injector inj, Visitor visitor) {
+		if (inj == null)
+			return;
+
+		accept(inj.getParent(), visitor);
+
+		for (final Binding<?> binding: inj.getBindings().values()) {
+			final Type type = binding.getKey().getTypeLiteral().getType();
+
+			if (type instanceof Class && Handler.class.isAssignableFrom((Class)type)) {
+				visitor.visit((Handler)binding.getProvider().get());
+			}
+		}
+	}
+}

--- a/gwizard-web/src/main/java/org/gwizard/web/HandlerScanner.java
+++ b/gwizard-web/src/main/java/org/gwizard/web/HandlerScanner.java
@@ -23,7 +23,7 @@ public class HandlerScanner {
 		this.injector = injector;
 	}
 
-	/** Start the process, visiting each ServletContextListener bound in the injector or any parents */
+	/** Start the process, visiting each Handler bound in the injector or any parents */
 	public void accept(Visitor visitor) {
 		accept(injector, visitor);
 	}


### PR DESCRIPTION
Follow the pattern of EventListenerScanner to enable injecting handlers.

For example, very useful for using logback-access to handle jetty request logs.