### PR TITLE
Upgrading Guice 4.0 and other dependencies

### DIFF
--- a/gwizard-hibernate/pom.xml
+++ b/gwizard-hibernate/pom.xml
@@ -21,9 +21,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
-			<version>4.3.7.Final</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>

--- a/gwizard-hibernate/src/main/java/com/google/inject/persist/jpa/WizardBridgeModule.java
+++ b/gwizard-hibernate/src/main/java/com/google/inject/persist/jpa/WizardBridgeModule.java
@@ -3,6 +3,8 @@ package com.google.inject.persist.jpa;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import org.gwizard.hibernate.DatabaseConfig;
+
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -22,7 +24,7 @@ public class WizardBridgeModule extends AbstractModule {
 	 */
 	@Provides
 	@Jpa
-	public Properties properties(DatabaseConfig cfg) {
+	public Map<?, ?> properties(DatabaseConfig cfg) {
 		Properties props = new Properties();
 		props.setProperty("hibernate.connection.driver_class", cfg.getDriverClass());
 		props.setProperty("hibernate.connection.url", cfg.getUrl());

--- a/gwizard-hibernate/src/main/java/com/google/inject/persist/jpa/WizardBridgeModule.java
+++ b/gwizard-hibernate/src/main/java/com/google/inject/persist/jpa/WizardBridgeModule.java
@@ -7,6 +7,8 @@ import org.gwizard.hibernate.DatabaseConfig;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.hibernate.cfg.AvailableSettings.*;
+
 /**
  * This allows us to pull database config out of Guice instead of hardcoding it in the
  * JpaPersistModule module as designed. Because we need access to the package-protected @Jpa
@@ -26,10 +28,10 @@ public class WizardBridgeModule extends AbstractModule {
 	@Jpa
 	public Map<?, ?> properties(DatabaseConfig cfg) {
 		Properties props = new Properties();
-		props.setProperty("hibernate.connection.driver_class", cfg.getDriverClass());
-		props.setProperty("hibernate.connection.url", cfg.getUrl());
-		props.setProperty("hibernate.connection.username", cfg.getUser());
-		props.setProperty("hibernate.connection.password", cfg.getPassword());
+		props.setProperty(DRIVER, cfg.getDriverClass());
+		props.setProperty(URL, cfg.getUrl());
+		props.setProperty(USER, cfg.getUser());
+		props.setProperty(PASS, cfg.getPassword());
 
 		props.putAll(cfg.getProperties());
 

--- a/gwizard-hibernate/src/test/java/org/gwizard/hibernate/HibernateModuleTest.java
+++ b/gwizard-hibernate/src/test/java/org/gwizard/hibernate/HibernateModuleTest.java
@@ -1,0 +1,53 @@
+package org.gwizard.hibernate;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.gwizard.hibernate.example.HibernateModuleExample.MyModule;
+import org.testng.annotations.Test;
+
+import javax.persistence.EntityManagerFactory;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.StrictAssertions.entry;
+import static org.gwizard.hibernate.example.HibernateModuleExample.Work;
+import static org.hibernate.cfg.AvailableSettings.DIALECT;
+import static org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO;
+
+public class HibernateModuleTest {
+
+    @Test
+    public void bridgeModuleOverridesJpaProperties() {
+        // given
+        MyModule myModule = new MyModule();
+        Map<String, String> configProperties = myModule.databaseConfig().getProperties();
+        Injector injector = Guice.createInjector(myModule, new HibernateModule());
+
+        // when
+        EntityManagerFactory entityManagerFactory = injector.getInstance(EntityManagerFactory.class);
+
+        assertThat(entityManagerFactory.getProperties()).contains(
+                entry(DIALECT, configProperties.get(DIALECT)),
+                entry(HBM2DDL_AUTO, configProperties.get(HBM2DDL_AUTO))
+        );
+        entityManagerFactory.close();
+    }
+
+    @Test
+    public void canPersistAndQueryEntityManager() {
+        // given
+        MyModule myModule = new MyModule();
+        Injector injector = Guice.createInjector(myModule, new HibernateModule());
+        Work work = injector.getInstance(Work.class);
+
+        // when
+        assert(work.countThings()) == 0;
+        work.makeAThing();
+        work.makeAThing();
+        work.makeAThing();
+
+        // then
+        assert(work.countThings()) == 3;
+        injector.getInstance(EntityManagerFactory.class).close();
+    }
+}

--- a/gwizard-hibernate/src/test/java/org/gwizard/hibernate/example/HibernateModuleExample.java
+++ b/gwizard-hibernate/src/test/java/org/gwizard/hibernate/example/HibernateModuleExample.java
@@ -5,10 +5,11 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.persist.Transactional;
-import org.gwizard.hibernate.DatabaseConfig;
-import org.gwizard.hibernate.HibernateModule;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.gwizard.hibernate.DatabaseConfig;
+import org.gwizard.hibernate.HibernateModule;
+
 import javax.inject.Singleton;
 import javax.persistence.Entity;
 import javax.persistence.EntityManagerFactory;
@@ -16,7 +17,10 @@ import javax.persistence.Id;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import java.util.UUID;
+
 import static org.gwizard.hibernate.EM.em;
+import static org.hibernate.cfg.AvailableSettings.DIALECT;
+import static org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO;
 
 /**
  * Self-contained example of using Hibernate
@@ -59,8 +63,8 @@ public class HibernateModuleExample {
 			cfg.setDriverClass("org.h2.Driver");
 			cfg.setUser("sa");
 			cfg.setUrl("jdbc:h2:mem:test");
-			cfg.getProperties().put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
-			cfg.getProperties().put("hibernate.hbm2ddl.auto", "create");
+			cfg.getProperties().put(DIALECT, "org.hibernate.dialect.H2Dialect");
+			cfg.getProperties().put(HBM2DDL_AUTO, "create");
 			return cfg;
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -27,18 +27,18 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<jetty.version>9.2.6.v20141205</jetty.version>
+		<jetty.version>9.3.1.v20150714</jetty.version>
 		<resteasy.version>3.0.10.Final</resteasy.version>
-		<jackson.version>2.5.0</jackson.version>
+		<jackson.version>2.5.4</jackson.version>
 		<guice.version>4.0</guice.version>
-		<slf4j.version>1.7.7</slf4j.version>
+		<slf4j.version>1.7.12</slf4j.version>
 		<logback.version>1.1.2</logback.version>
 		<guava.version>18.0</guava.version>
-		<metrics.version>3.1.0</metrics.version>
+		<metrics.version>3.1.2</metrics.version>
 		<metricsguice.version>3.1.3</metricsguice.version>
-		<dropwizard.version>0.7.1</dropwizard.version>
-		<hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
-		<snakeyaml.version>1.14</snakeyaml.version>
+		<dropwizard.version>0.8.1</dropwizard.version>
+		<hibernate.validator.version>5.2.1.Final</hibernate.validator.version>
+		<snakeyaml.version>1.15</snakeyaml.version>
 	</properties>
 
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
 		<metrics.version>3.1.2</metrics.version>
 		<metricsguice.version>3.1.3</metricsguice.version>
 		<dropwizard.version>0.8.1</dropwizard.version>
-		<hibernate.validator.version>5.2.1.Final</hibernate.validator.version>
+        <hibernate.em.version>5.0.0.CR3</hibernate.em.version>
+		<hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
 		<snakeyaml.version>1.15</snakeyaml.version>
 	</properties>
 
@@ -243,6 +244,12 @@
 			<version>1.9.5</version>
 			<scope>test</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.1.0</version>
+        </dependency>
 	</dependencies>
 
 	<dependencyManagement>
@@ -359,6 +366,11 @@
 			</dependency>
 
 			<!-- hibernate -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-entitymanager</artifactId>
+                <version>${hibernate.em.version}</version>
+            </dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-validator</artifactId>


### PR DESCRIPTION
- Upgrading `Guice 4.0` introduced a breaking change due to `JpaPersistService` where Jpa properties are not injected. Updated `WizardBridgeModule` accordingly and added junit tests (with assertj) to cover such scenarios.
- Updated Hibernate version and used `Environment` constants instead of hard coded strings 
- Upgraded a few dependencies in the pom such as Jetty, DW, metrics, jackson etc. 

Tested by:
- running all junit tests
- running all example `main()` methods in the `test` packages one by one
- running `gwizard-example` against snapshot and also running all junit tests in `gwizard-example`