### PR TITLE
Change AssertJ dependency and include initial Swagger support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 target
 dependency-reduced-pom.xml
+.project
+.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 dependency-reduced-pom.xml
 .project
 .classpath
+/.settings/

--- a/gwizard-config/.gitignore
+++ b/gwizard-config/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-healthchecks/.gitignore
+++ b/gwizard-healthchecks/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-hibernate/.gitignore
+++ b/gwizard-hibernate/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/test-output/

--- a/gwizard-hibernate/src/test/java/org/gwizard/hibernate/HibernateModuleTest.java
+++ b/gwizard-hibernate/src/test/java/org/gwizard/hibernate/HibernateModuleTest.java
@@ -1,18 +1,19 @@
 package org.gwizard.hibernate;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import org.gwizard.hibernate.example.HibernateModuleExample.MyModule;
-import org.testng.annotations.Test;
-
-import javax.persistence.EntityManagerFactory;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.entry;
-import static org.gwizard.hibernate.example.HibernateModuleExample.Work;
 import static org.hibernate.cfg.AvailableSettings.DIALECT;
 import static org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO;
+
+import java.util.Map;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.gwizard.hibernate.example.HibernateModuleExample.MyModule;
+import org.gwizard.hibernate.example.HibernateModuleExample.Work;
+import org.testng.annotations.Test;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 
 public class HibernateModuleTest {
 
@@ -26,10 +27,10 @@ public class HibernateModuleTest {
 		// when
 		EntityManagerFactory entityManagerFactory = injector.getInstance(EntityManagerFactory.class);
 
-		assertThat(entityManagerFactory.getProperties()).contains(
-				entry(DIALECT, configProperties.get(DIALECT)),
-				entry(HBM2DDL_AUTO, configProperties.get(HBM2DDL_AUTO))
-		);
+		Map<String, Object> actual = entityManagerFactory.getProperties();
+		assertThat(actual.get(DIALECT)).isEqualTo(configProperties.get(DIALECT));
+		assertThat(actual.get(HBM2DDL_AUTO)).isEqualTo(configProperties.get(HBM2DDL_AUTO));
+
 		entityManagerFactory.close();
 	}
 

--- a/gwizard-jersey/.gitignore
+++ b/gwizard-jersey/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-logging/.gitignore
+++ b/gwizard-logging/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-metrics/.gitignore
+++ b/gwizard-metrics/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-rest/.gitignore
+++ b/gwizard-rest/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-rpc/.gitignore
+++ b/gwizard-rpc/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-services/.gitignore
+++ b/gwizard-services/.gitignore
@@ -1,0 +1,3 @@
+/.classpath
+/.project
+/.settings/

--- a/gwizard-swagger/.gitignore
+++ b/gwizard-swagger/.gitignore
@@ -1,0 +1,4 @@
+/test-output/
+.project
+.classpath
+.settings

--- a/gwizard-swagger/README.md
+++ b/gwizard-swagger/README.md
@@ -1,0 +1,105 @@
+# GWizard Swagger
+
+
+GWizard Swagger servess a swagger configuration file generated from your JAX-RS 
+resources and @Api annoted methods. At the moment, only the swagger json or yaml
+file is provided and not the complete swagger-ui.
+
+See https://github.com/swagger-api/swagger-core
+
+## Usage
+
+* Add the Maven dependency
+
+```xml
+	<dependency>
+		<groupId>org.gwizard</groupId>
+		<artifactId>gwizard-swagger</artifactId>
+		<version>${gwizard.version}</version>
+	</dependency>
+```
+
+* Add the Swagger configuration to your application's config
+
+```java
+	@Data
+	public class ExampleConfig {
+		...	
+		private SwaggerConfig swagger = new SwaggerConfig();
+		...
+	}
+```
+
+* Add the Swagger configuration provider to your applications Guice module
+
+```java	
+	@Provides
+	public SwaggerConfig swaggerConfig(ExampleConfig cfg) {
+		return cfg.getSwagger();
+	}
+```
+
+* Add the configuration to your applications configuration file
+
+```
+	swagger:
+	  resourcePackages: com.example.app.resource
+```
+
+* Load the Swagger module in your Main method
+
+```java
+	public class Main {
+		public static void main(String[] args) throws Exception {
+			if (args.length < 1) {
+				System.err.println("First argument needs to be a yaml config file, doofus");
+				return;
+			}
+			Injector injector = Guice.createInjector(
+					...
+					new SwaggerModule());
+			injector.getInstance(Run.class).start();
+		}
+	}
+```
+
+* Add the Swagger annotations to your resource classes and classes
+
+* Create an interface in you base resource package for the main api documentation 
+
+```java
+	@SwaggerDefinition(
+		info = @Info(
+		  description = "Example Gwizard App",
+		  version = "V1.0.1",
+		  title = "The GWizard Example API",
+		  termsOfService = "http://localhost:8081/terms.html",
+		  contact = @Contact(
+				name = "Gandalf", 
+				email = "into.shadow@middleearth.org", 
+				url = "http://middleearth.org"
+		  ),
+		  license = @License(
+				name = "Apache 2.0", 
+				url = "http://www.apache.org/licenses/LICENSE-2.0"
+		  )
+		),
+		consumes = {"application/json", "application/xml"},
+		produces = {"application/json", "application/xml"},
+		schemes = {SwaggerDefinition.Scheme.HTTP, SwaggerDefinition.Scheme.HTTPS},
+		tags = {
+				@Tag(name = "Private", description = "Tag used to denote operations as private")
+		}, 
+		externalDocs = @ExternalDocs(value = "Rings", url = "http://ringsapi.io/middleearth.html")
+	)
+	public interface ExampleApiConfig { /* empty */ }
+```
+
+## Sample Application
+
+[A self-contained example](src/test/java/org/gwizard/services/example/ServicesModuleExample.java)
+
+## Notes
+
+Swagger 2 does not need the host and port to be specified as it will use the relative url from
+where the configuration is loaded from.

--- a/gwizard-swagger/pom.xml
+++ b/gwizard-swagger/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.gwizard</groupId>
+		<artifactId>gwizard-parent</artifactId>
+		<version>0.7-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>gwizard-swagger</artifactId>
+	<name>GWizard Swagger</name>
+	<packaging>jar</packaging>
+	
+	<dependencies>
+
+		<dependency>
+		    <groupId>org.jboss.resteasy</groupId>
+		    <artifactId>jaxrs-api</artifactId>
+		    <scope>provided</scope>
+		</dependency>
+
+		<!-- start: guice -->	
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.inject.extensions</groupId>
+			<artifactId>guice-servlet</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.google.inject.extensions</groupId>
+			<artifactId>guice-multibindings</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		
+		<!-- end: guice -->	
+		
+		<!-- start: swagger -->
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+            	<exclusion>
+            		<artifactId>jsr311-api</artifactId>
+            		<groupId>javax.ws.rs</groupId>
+            	</exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+        </dependency>
+        <!-- end: swagger -->
+
+		<!-- This is just for running tests -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+    </dependencies>
+</project>

--- a/gwizard-swagger/src/main/java/org/gwizard/swagger/ApiOriginFilter.java
+++ b/gwizard-swagger/src/main/java/org/gwizard/swagger/ApiOriginFilter.java
@@ -1,0 +1,35 @@
+package org.gwizard.swagger;
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.inject.Singleton;
+
+/**
+ * Allow CORS --> Swagger specification api.
+ */
+@Singleton
+final class ApiOriginFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+    HttpServletResponse r = (HttpServletResponse) res;
+    r.addHeader("Access-Control-Allow-Origin", "*");
+    r.addHeader("Access-Control-Allow-Headers", "Content-Type");
+    r.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+    chain.doFilter(req, res);
+  }
+
+  @Override
+  public void destroy() {}
+
+  @Override
+  public void init(FilterConfig fc) throws ServletException {}
+  
+}

--- a/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerConfig.java
+++ b/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerConfig.java
@@ -1,0 +1,55 @@
+package org.gwizard.swagger;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import org.assertj.core.util.Lists;
+
+import lombok.Data;
+
+/**
+ * This is the root configuration object for the API specification.
+ * All field names in the specification are case sensitive.
+ */
+@Data
+public final class SwaggerConfig {
+
+	/*
+	 * The swagger spcification can be faound here: http://swagger.io/specification/
+	 * These fields follow the specification.
+	 */
+	
+	/**
+	 * Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to 
+	 * interpret the API listing. The value MUST be "2.0".
+	 */
+	@NotNull 
+	private String swagger = "2.0";
+	
+	/**
+	 * The host (name or ip) serving the API. This MUST be the host only and does not include the scheme nor sub-paths. 
+	 * It MAY include a port. If the host is not included, the host serving the documentation is to be used (including 
+	 * the port). The host does not support path templating.
+	 */
+	private String host = "localhost";
+	
+	/**
+	 * The base path on which the API is served, which is relative to the host. If it is not included, the API is served 
+	 * directly under the host. The value MUST start with a leading slash (/). The basePath does not support path 
+	 * templating.
+	 */
+	private String basePath;
+	
+	/**
+	 * The resource packages that should be scanned
+	 */
+	@NotNull 
+	private List<String> resourcePackages = Lists.newArrayList();
+
+	/**
+	 * Pretty print the api specification. Normally you'd have this set to true
+	 */
+	private boolean prettyPrint = true;
+
+}

--- a/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerModule.java
+++ b/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerModule.java
@@ -1,0 +1,27 @@
+package org.gwizard.swagger;
+
+
+import javax.servlet.ServletContextListener;
+
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.servlet.ServletModule;
+
+import io.swagger.jaxrs.listing.ApiListingResource;
+import io.swagger.jaxrs.listing.SwaggerSerializers;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EqualsAndHashCode(callSuper=false, of={})	// makes installation of this module idempotent
+public class SwaggerModule extends ServletModule {
+	
+	@Override
+	protected void configureServlets() {
+		log.debug("Configuring swagger guice module...");
+		Multibinder.newSetBinder(binder(), ServletContextListener.class).addBinding().to(SwaggerServletContextListener.class);
+		bind(ApiListingResource.class);
+    bind(SwaggerSerializers.class);
+    filter("/*").through(ApiOriginFilter.class);
+	}
+	
+}

--- a/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerServletContextListener.java
+++ b/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerServletContextListener.java
@@ -1,0 +1,73 @@
+package org.gwizard.swagger;
+import java.util.List;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import com.google.common.base.Joiner;
+import com.google.inject.Inject;
+
+import io.swagger.config.ScannerFactory;
+import io.swagger.jaxrs.config.BeanConfig;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A context listener that scans for APIs and configures Swagger.
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ */
+@Slf4j
+final class SwaggerServletContextListener implements ServletContextListener {
+	
+  private final SwaggerConfig swaggerConfig;
+  
+  /**
+   * @param injector
+   * @param swaggerConfig
+   */
+  @Inject
+  SwaggerServletContextListener(SwaggerConfig swaggerConfig) {
+    this.swaggerConfig = swaggerConfig;
+  }
+
+  @Override
+  public void contextInitialized(ServletContextEvent event) {
+  	log.debug("Handling servlet context event. Configuring Swagger...");
+    BeanConfig beanConfig = createBeanConfig(swaggerConfig);
+    event.getServletContext().setAttribute("reader", beanConfig);
+    event.getServletContext().setAttribute("swagger", beanConfig.getSwagger());
+    event.getServletContext().setAttribute("scanner", ScannerFactory.getScanner());
+  }
+
+  /**
+   * Returns a newly configured {@code BeanConfig} using the provided {@code swaggerConfig}
+   * 
+   * @param swaggerConfig The configuration to use
+   * @return a newly configured {@code BeanConfig}
+   */
+  static BeanConfig createBeanConfig(SwaggerConfig swaggerConfig) {
+	  
+    BeanConfig beanConfig = new BeanConfig();
+    
+    beanConfig.setScan(true);
+    beanConfig.setHost(swaggerConfig.getHost());
+    beanConfig.setBasePath(swaggerConfig.getBasePath());
+    beanConfig.setPrettyPrint(swaggerConfig.isPrettyPrint());
+
+    // Must be called last!
+    List<String> resourcePackages = swaggerConfig.getResourcePackages();
+    beanConfig.setResourcePackage(Joiner.on(",").join(resourcePackages));
+    if (resourcePackages.isEmpty()) {
+    	log.warn("No resource packages configured");
+    } else {
+      log.debug("Added resource packages {} to swagger bean config", resourcePackages);
+    }
+
+    return beanConfig;
+    
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent event) { /* empty */ }
+  
+}

--- a/gwizard-swagger/src/test/java/org/gwizard/swagger/SwaggerServletContextListenerTest.java
+++ b/gwizard-swagger/src/test/java/org/gwizard/swagger/SwaggerServletContextListenerTest.java
@@ -1,0 +1,43 @@
+/**
+ * 
+ */
+package org.gwizard.swagger;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.Swagger;
+
+/**
+ * @author darren
+ *
+ */
+public class SwaggerServletContextListenerTest {
+
+	@Test
+	public void testGetBeanConfig() {
+
+		SwaggerConfig swaggerConfig = new SwaggerConfig();
+
+		swaggerConfig.setHost("localhost:8081");
+		swaggerConfig.setBasePath("/");
+		swaggerConfig.setResourcePackages(Lists.newArrayList("com.gwizard", "com.belldj"));
+
+		BeanConfig beanConfig = SwaggerServletContextListener.createBeanConfig(swaggerConfig);
+
+		assertThat(beanConfig).isNotNull();
+		assertThat(beanConfig.getScan()).isEqualTo(true);
+		assertThat(beanConfig.getHost()).isEqualTo("localhost:8081");
+		assertThat(beanConfig.getBasePath()).isEqualTo("/");
+		assertThat(beanConfig.getResourcePackage()).isEqualTo("com.gwizard,com.belldj");
+
+		Swagger swagger = beanConfig.getSwagger();
+
+		assertThat(swagger).isNotNull();
+	}
+}

--- a/gwizard-web/.gitignore
+++ b/gwizard-web/.gitignore
@@ -1,0 +1,4 @@
+/test-output/
+.project
+.classpath
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<module>gwizard-healthchecks</module>
 		<module>gwizard-metrics</module>
 		<module>gwizard-rpc</module>
+		<module>gwizard-swagger</module>
 	</modules>
 
 	<properties>
@@ -37,9 +38,13 @@
 		<metrics.version>3.1.2</metrics.version>
 		<metricsguice.version>3.1.3</metricsguice.version>
 		<dropwizard.version>0.8.1</dropwizard.version>
-        <hibernate.em.version>5.0.0.CR3</hibernate.em.version>
+        	<hibernate.em.version>5.0.0.CR3</hibernate.em.version>
 		<hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
 		<snakeyaml.version>1.15</snakeyaml.version>
+		<swagger.version>1.5.8</swagger.version>
+		<servlet-api.version>2.5</servlet-api.version>
+		<jaxrs-api.version>3.0.10.Final</jaxrs-api.version>
+		<assertj.version>2.4.1</assertj.version>
 	</properties>
 
 	<scm>
@@ -377,6 +382,35 @@
 				<version>${hibernate.validator.version}</version>
 			</dependency>
 
+			<!-- swagger -->
+	        <dependency>
+	            <groupId>io.swagger</groupId>
+	            <artifactId>swagger-jaxrs</artifactId>
+	            <version>${swagger.version}</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>io.swagger</groupId>
+	            <artifactId>swagger-annotations</artifactId>
+	            <version>${swagger.version}</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>io.swagger</groupId>
+	            <artifactId>swagger-rest</artifactId>
+	            <version>${swagger.version}</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>javax.servlet</groupId>
+	            <artifactId>servlet-api</artifactId>
+	            <version>${servlet-api.version}</version>
+	        </dependency>
+
+			<!-- RESTEasy -->
+			<dependency>
+			    <groupId>org.jboss.resteasy</groupId>
+			    <artifactId>jaxrs-api</artifactId>
+			    <version>${jaxrs-api.version}</version>
+			</dependency>
+	  
 		</dependencies>
 	</dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.1.0</version>
+            <version>2.4.1</version>
         </dependency>
 	</dependencies>
 


### PR DESCRIPTION
On checkout, GWizard will not build under Java 7. The version of AssertJ was set to 3.1.0 which is Java 8 only. I have updated this dependency to 2.4.1 and removes some AssertJ features specific to the Java 8 version.