### PR TITLE
Set packages to scan before scan is performed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 dependency-reduced-pom.xml
 .project
 .classpath
+/.settings/

--- a/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerServletContextListener.java
+++ b/gwizard-swagger/src/main/java/org/gwizard/swagger/SwaggerServletContextListener.java
@@ -49,7 +49,6 @@ final class SwaggerServletContextListener implements ServletContextListener {
 	  
     BeanConfig beanConfig = new BeanConfig();
     
-    beanConfig.setScan(true);
     beanConfig.setHost(swaggerConfig.getHost());
     beanConfig.setBasePath(swaggerConfig.getBasePath());
     beanConfig.setPrettyPrint(swaggerConfig.isPrettyPrint());
@@ -62,6 +61,9 @@ final class SwaggerServletContextListener implements ServletContextListener {
     } else {
       log.debug("Added resource packages {} to swagger bean config", resourcePackages);
     }
+
+    // setScan() actually performs it! (must go last.
+    beanConfig.setScan(true);
 
     return beanConfig;
     

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,1 @@
+language: java


### PR DESCRIPTION
setScan(true) was being performed before the packages were being set. I didn't realise that setScan actually fired it (hmmmm).

If you pull in this PR, then you may want to edit or remove the Travis indicator from readme.